### PR TITLE
feat: full-viewport layout and full-width footer

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -24,7 +24,7 @@ useHead({
 </script>
 
 <template>
-  <div class="relative bg-default">
+  <div class="relative bg-default flex flex-col h-dvh overflow-hidden">
     <TheNav />
 
     <!-- Dot pattern background -->
@@ -36,7 +36,10 @@ useHead({
       }"
     />
 
-    <NuxtPage />
+    <div class="flex-1 overflow-y-auto">
+      <NuxtPage />
+    </div>
+
+    <TheFooter />
   </div>
-  <TheFooter />
 </template>

--- a/app/components/TheFooter.vue
+++ b/app/components/TheFooter.vue
@@ -19,7 +19,7 @@ const socialLinks = [
 </script>
 
 <template>
-  <footer class="mt-auto p-4 max-w-2xl mx-auto w-full font-mono">
+  <footer class="mt-auto p-4 w-full font-mono">
     <div class="flex items-center justify-between gap-4">
       <!-- Logo Section -->
       <div class="flex items-center gap-3">

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -14,7 +14,7 @@ const skills: string[] = [
 
 <template>
   <main
-    class="max-w-2xl mx-auto flex flex-col px-6 pt-0 sm:pt-20 relative container mx-auto min-h-[85dvh] font-mono"
+    class="max-w-2xl mx-auto flex flex-col px-6 pt-0 sm:pt-20 relative container mx-auto font-mono"
   >
     <span
       class="inline-flex items-center justify-center shrink-0 select-none rounded-full align-middle bg-elevated size-24 text-xl"


### PR DESCRIPTION
This change updates the application's layout to ensure it fits within the viewport height without causing a global scrollbar. The footer now occupies the full width of the screen. The main content area remains scrollable independently if it exceeds the available space, while the navigation and footer stay fixed at the top and bottom respectively.

---
*PR created automatically by Jules for task [10359729662003982424](https://jules.google.com/task/10359729662003982424) started by @sebastiandotdev*